### PR TITLE
Fixed Some bugs and added some small features

### DIFF
--- a/client/menusetup.lua
+++ b/client/menusetup.lua
@@ -1,13 +1,14 @@
 ------------------- Variables ------------------------------------
-StopAll = false           --This is the variable used for the dead check
-local level = 0           --Creates a variable to store the players level client side(sets to 0 when you join server)
-local subtractamoount = 0 --Creates a variable used to store the amount to subtract off cost based on your level if config.level is true
+StopAll = false -- This is the variable used for the dead check
+local level = 0 -- Creates a variable to store the players level client side(sets to 0 when you join server)
+local subtractamoount = 0 -- Creates a variable used to store the amount to subtract off cost based on your level if config.level is true
+local elem = {}
 ----------------------------------------- Menu Setup -----------------------------------------
 TriggerEvent("menuapi:getData", function(call)
     MenuData = call
 end)
 
---This closes the menu when you stop or restart the resources.
+-- This closes the menu when you stop or restart the resources.
 AddEventHandler("onResourceStop", function(resourceName)
     if resourceName ~= GetCurrentResourceName() then
         return
@@ -15,13 +16,13 @@ AddEventHandler("onResourceStop", function(resourceName)
     MenuData.CloseAll()
 end)
 
---this is used to close the menu while you are on the main menu and hit backspace button
+-- this is used to close the menu while you are on the main menu and hit backspace button
 RegisterNetEvent('bcc-legendaries:MenuClose')
 AddEventHandler('bcc-legendaries:MenuClose', function()
-    while true do --loops will run permantely
-        Citizen.Wait(10) --waits 10ms prevents crashing
-        if IsControlJustReleased(0, 0x156F7119) then --if backspace is pressed then
-            MenuData.CloseAll() --closes all menus
+    while true do -- loops will run permantely
+        Citizen.Wait(10) -- waits 10ms prevents crashing
+        if IsControlJustReleased(0, 0x156F7119) then -- if backspace is pressed then
+            MenuData.CloseAll() -- closes all menus
         end
     end
 end)
@@ -30,43 +31,47 @@ local huntlocation
 RegisterNetEvent('bcc:legendaries:openmenu')
 AddEventHandler('bcc:legendaries:openmenu', function(location)
     huntlocation = location
-    local elements = {} --sets the var to a table
-    local elementindex = 1 --sets the var too 1
-    Citizen.Wait(100) --waits 100ms
-    TriggerEvent('bcc-legendaries:MenuClose') --triggers the event
-    MenuData.CloseAll() --closes all menus
-    for k, items in pairs(Config.locations) do --opens a for loop
+    local elements = {} -- sets the var to a table
+    local elementindex = 1 -- sets the var too 1
+    Citizen.Wait(100) -- waits 100ms
+    TriggerEvent('bcc-legendaries:MenuClose') -- triggers the event
+    MenuData.CloseAll() -- closes all menus
+    for k, items in pairs(Config.locations) do -- opens a for loop
         if items.location == huntlocation then
             if Config.LevelSystem then
                 if items.level <= level then
                     Cost = items.hintcost - subtractamoount
-                    elements[elementindex] = { --sets the elemnents to this table
-                    label = items.huntname .. ' ' .. Cost .. '$', --sets the label
-                    value = 'buyhint' .. tostring(elementindex), --sets the value
-                    desc = '', --empty desc
-                    info = items --sets info to the table(this will allow you too open the table in the menu setup below)
+                    elements[elementindex] = { -- sets the elemnents to this table
+                        label = items.huntname .. ' ' .. Cost .. '$', -- sets the label
+                        value = 'buyhint' .. tostring(elementindex), -- sets the value
+                        desc = '', -- empty desc
+                        info = items -- sets info to the table(this will allow you too open the table in the menu setup below)
                     }
-                    elementindex = elementindex + 1 --adds 1 to the var
+                    elementindex = elementindex + 1 -- adds 1 to the var
                 end
+                elem = elements
             else
                 Cost = items.hintcost
-                elements[elementindex] = { --sets the elemnents to this table
-                    label = items.huntname .. ' ' .. Cost .. '$', --sets the label
-                    value = 'buyhint' .. tostring(elementindex), --sets the value
-                    desc = '', --empty desc
-                    info = items --sets info to the table(this will allow you too open the table in the menu setup below)
+                elements[elementindex] = { -- sets the elemnents to this table
+                    label = items.huntname .. ' ' .. Cost .. '$', -- sets the label
+                    value = 'buyhint' .. tostring(elementindex), -- sets the value
+                    desc = '', -- empty desc
+                    info = items -- sets info to the table(this will allow you too open the table in the menu setup below)
                 }
-                elementindex = elementindex + 1 --adds 1 to the var
+                elementindex = elementindex + 1 -- adds 1 to the var
             end
         end
     end
-    MenuData.Open('default', GetCurrentResourceName(), 'menuapi', {
-        title = Config.Language.Menuname,
-        align = 'top-left',
-        elements = elements,
-        lastmenu = "MainMenu"
-    },
-        function(data)
+    local next = next
+    if next(elem) == nil then
+        VORPcore.NotifyBottomRight(Config.Language.Nolevel, 6000) -- text in bottom right
+    else
+        MenuData.Open('default', GetCurrentResourceName(), 'menuapi', {
+            title = Config.Language.Menuname,
+            align = 'top-left',
+            elements = elements,
+            lastmenu = "MainMenu"
+        }, function(data)
             if (data.current == "backup") then
                 _G[data.trigger]()
             else
@@ -77,10 +82,10 @@ AddEventHandler('bcc:legendaries:openmenu', function(location)
                 else
                     Cost = data.current.info.hintcost
                 end
-                TriggerServerEvent('bcc:legendaries:menuopen5', Cost)                                                                                  --triggers the server cooldown event
-                RegisterNetEvent('bcc:legendaries:menuopen4')                                                                                          --creates a client event
-                AddEventHandler('bcc:legendaries:menuopen4', function()                                                                                                                         --adds a function to the client event
-                    Animal = data.current.info.pedmodel                                                                                                                  --sets varible to the config option to be used in the other .lua files
+                TriggerServerEvent('bcc:legendaries:menuopen5', Cost) -- triggers the server cooldown event
+                RegisterNetEvent('bcc:legendaries:menuopen4') -- creates a client event
+                AddEventHandler('bcc:legendaries:menuopen4', function() -- adds a function to the client event
+                    Animal = data.current.info.pedmodel -- sets varible to the config option to be used in the other .lua files
                     Animalcoords = data.current.info.coordinates
                     Npccoords = data.current.info.Npccoords
                     Npcblipcoords = data.current.info.npcblipcoord
@@ -93,18 +98,19 @@ AddEventHandler('bcc:legendaries:openmenu', function(location)
                     Secondarynpcspawn = data.current.info.SecondaryAnimals.Animalspawns
                     Secondarynpcboolean = data.current.info.SecondaryAnimals.secondaryanimals
                     Secondarynpcmodel = data.current.info.SecondaryAnimals.animalmodel
-                    VORPcore.NotifyBottomRight(Config.Language.Initialblipmark, 2000) --text in bottom right
-                    offcatcher()                                                      --triggers offcatcher
-                    searchsetupmain('InitSearch', Investigate.x, Investigate.y, Investigate.z)       --triggers the search setup
+                    VORPcore.NotifyBottomRight(Config.Language.Initialblipmark, 2000) -- text in bottom right
+                    offcatcher() -- triggers offcatcher
+                    searchsetupmain('InitSearch', Investigate.x, Investigate.y, Investigate.z) -- triggers the search setup
                 end)
             end
         end)
+    end
 end)
 
 -------- Event to tell you cooldown is active ------------------------
 RegisterNetEvent('bcc:legendaries:failmenuopen')
 AddEventHandler('bcc:legendaries:failmenuopen', function()
-    VORPcore.NotifyBottomRight(Config.Language.Cooldownactive, 6000) --text in bottom right
+    VORPcore.NotifyBottomRight(Config.Language.Cooldownactive, 6000) -- text in bottom right
 end)
 
 ---------------- Creates a thread(runs on start) to check if your near the coords an hit the g button -----------------------
@@ -115,13 +121,13 @@ Citizen.CreateThread(function()
             if GetDistanceBetweenCoords(v.Pos.x, v.Pos.y, v.Pos.z, GetEntityCoords(PlayerPedId()), false) < 2 then
                 if IsControlJustReleased(0, 0x760A9C6F) then
                     if Config.LevelSystem == true then
-                        TriggerServerEvent('bcc:legendaries:DBCheck')       --triggers server event that makes sure you exist in the db
-                        Wait(500)                                           --waits 150 ms gives server time to check
-                        TriggerServerEvent('bcc:legendaries:GetTrustLevel') --triggers server event to get your level
-                        Wait(300)                                           --Waits 100ms gives server time to run
-                        levelcalc()                                         --triggers level check function
+                        TriggerServerEvent('bcc:legendaries:DBCheck') -- triggers server event that makes sure you exist in the db
+                        Wait(500) -- waits 150 ms gives server time to check
+                        TriggerServerEvent('bcc:legendaries:GetTrustLevel') -- triggers server event to get your level
+                        Wait(300) -- Waits 100ms gives server time to run
+                        levelcalc() -- triggers level check function
                     end
-                    TriggerEvent('bcc:legendaries:openmenu', v.name)        --Trigger Menu Event with location name
+                    TriggerEvent('bcc:legendaries:openmenu', v.name) -- Trigger Menu Event with location name
                 end
             end
         end
@@ -131,18 +137,18 @@ end)
 ------------------------ Level Catch Setup ---------------------------------
 RegisterNetEvent('bcc:legendaries:ClientLevelCatch')
 AddEventHandler('bcc:legendaries:ClientLevelCatch',
-    function(trust, sentname) --Catches the trust variable from the server
+    function(trust, sentname) -- Catches the trust variable from the server
         level = trust
     end)
 
 ------------------------------------ Dead check Setup -------------------------------
 function offcatcher()
     Citizen.CreateThread(function()
-        while true do                                  --creates a loop
-            Citizen.Wait(1000)                         --prevents crashse
-            local op = IsPedDeadOrDying(PlayerPedId()) --deteces if the player is alive or dead if alive it prints false if ded it prints 1
-            if op == 1 then                            --if player is dead then it sets stop all to true
-                StopAll = true                         --global variable set to true
+        while true do -- creates a loop
+            Citizen.Wait(1000) -- prevents crashse
+            local op = IsPedDeadOrDying(PlayerPedId()) -- deteces if the player is alive or dead if alive it prints false if ded it prints 1
+            if op == 1 then -- if player is dead then it sets stop all to true
+                StopAll = true -- global variable set to true
                 break
             end
         end
@@ -151,12 +157,12 @@ end
 
 -------------------------------- Detecting Level -----------------------------
 function levelcalc()
-    for key, value in pairs(Config.Levels) do                    --creates a for loop in config.levels
-        if level >= value.level and level < value.nextlevel then --if level is greater than level, and less than the next then
+    for key, value in pairs(Config.Levels) do -- creates a for loop in config.levels
+        if level >= value.level and level < value.nextlevel then -- if level is greater than level, and less than the next then
             subtractamoount = value.costreduction
-            break                                                --sets the variable and breaks the loop
-        elseif level < value.level then                          --elseif you are not equal too or greater than the very first level then
-            break                                                --prints in client and breaks loop preventing the subtractamoount from being set(this keeps anyone below the first level from getting a reduction in cost)
+            break -- sets the variable and breaks the loop
+        elseif level < value.level then -- elseif you are not equal too or greater than the very first level then
+            break -- prints in client and breaks loop preventing the subtractamoount from being set(this keeps anyone below the first level from getting a reduction in cost)
         end
     end
 end

--- a/client/shopped.lua
+++ b/client/shopped.lua
@@ -1,22 +1,52 @@
-local npc = {}
-local x, y, z = {}, {}, {}
+local npcs = {}
+local blips = {}
+
 Citizen.CreateThread(function()
     Citizen.Wait(1000)
 
     for k, v in pairs(Config.shop) do
-        local model = GetHashKey('mp_re_slumpedhunter_males_01') --sets the npc model
+        local model = GetHashKey('mp_re_slumpedhunter_males_01') -- sets the npc model
         modelload(model)
 
-        npc = CreatePed(model, v.Pos.x, v.Pos.y, v.Pos.z - 1.0, v.Pos.h, false, false, true, true)
+        local npc = CreatePed(model, v.Pos.x, v.Pos.y, v.Pos.z - 1.0, v.Pos.h, false, false, true, true)
         Citizen.InvokeNative(0x283978A15512B2FE, npc, true)
         SetEntityCanBeDamaged(npc, false)
         SetEntityInvincible(npc, true)
         FreezeEntityPosition(npc, true)
         SetBlockingOfNonTemporaryEvents(npc, true)
-        x, y, z = v.Pos.x, v.Pos.y, v.Pos.z
+        
         if v.allowblip then
-            local blip = VORPutils.Blips:SetBlip(Config.Language.Hunterblip, 'blip_taxidermist', 0.8, x, y, z)
+            local blip = Citizen.InvokeNative(0x554D9D53F696D002, 1664425300, v.Pos.x, v.Pos.y, v.Pos.z) -- This create a blip with a defualt blip hash we given
+            SetBlipSprite(blip, v.BlipHash, 1) -- This sets the blip hash to the given in config.
+            SetBlipScale(blip, 0.8)
+            Citizen.InvokeNative(0x662D364ABF16DE2F, blip, joaat(v.BlipColor))
+            Citizen.InvokeNative(0x9CB1A1623062F402, blip, v.BlipName) -- Sets the blip Name
+            table.insert(blips, blip)
         end
+
+        table.insert(npcs, npc) -- Store the NPC in the npcs table
+    end
+end)
+
+-- Function to delete NPCs
+function DeleteNPCs()
+    for k, v in pairs(npcs) do
+        DeletePed(v)
+    end
+end
+
+-- Function to delete blips
+function DeleteBlips()
+    for k, v in pairs(blips) do
+        RemoveBlip(v)
+    end
+end
+
+-- Call the DeleteNPCs function when the resource stops
+AddEventHandler("onResourceStop", function(resource)
+    if resource == GetCurrentResourceName() then
+        DeleteNPCs()
+        DeleteBlips()
     end
 end)
 
@@ -29,7 +59,7 @@ Citizen.CreateThread(function()
         for k, v in pairs(Config.shop) do
             if GetDistanceBetweenCoords(coords, v.Pos.x, v.Pos.y, v.Pos.z, true) < 2.5 then
                 sleep = false
-                DrawText3D(v.Pos.x, v.Pos.y, v.Pos.z, Config.Language.Shoptext) --creates the text
+                DrawText3D(v.Pos.x, v.Pos.y, v.Pos.z, Config.Language.Shoptext) -- creates the text
             end
         end
         if sleep then
@@ -37,3 +67,5 @@ Citizen.CreateThread(function()
         end
     end
 end)
+
+

--- a/config.lua
+++ b/config.lua
@@ -5,11 +5,17 @@ Config.shop = {
         allowblip = true,
         name = "Saint Denis",
         Pos = {x = 1877.96, y = -1344.97, z = 42.49},
+        BlipHash = -1733535731,
+        BlipName = "Saint Denis Hunter",
+        BlipColor = "BLIP_MODIFIER_MP_COLOR_10",
     },
     shoplocation2 = {
-        allowblip = false,
+        allowblip = true,
         name = "Blackwater",
         Pos = { x = 1710.63, y = 1489.88, z = 146.52 },
+        BlipHash = -1733535731,
+        BlipName = "Blackwater Hunter",
+        BlipColor = "BLIP_MODIFIER_MP_COLOR_10",
     }
 }
 
@@ -229,5 +235,41 @@ Config.Language = {
     Shoptext = 'Press "G" to see what the hunter is offering',
     LegAnimalSpawned = 'The Animal is Nearby!',
     AnimalSkinned = 'You skinned the Animal, and got its pelt!',
-    Leveldisp = 'Your Current Level'
+    Leveldisp = 'Your Current Level',
+    Nolevel = 'You have not experinced enough to talk to me'
 }
+
+
+--[[--------BLIP_COLORS----------
+LIGHT_BLUE    = 'BLIP_MODIFIER_MP_COLOR_1',
+DARK_RED      = 'BLIP_MODIFIER_MP_COLOR_2',
+PURPLE        = 'BLIP_MODIFIER_MP_COLOR_3',
+ORANGE        = 'BLIP_MODIFIER_MP_COLOR_4',
+TEAL          = 'BLIP_MODIFIER_MP_COLOR_5',
+LIGHT_YELLOW  = 'BLIP_MODIFIER_MP_COLOR_6',
+PINK          = 'BLIP_MODIFIER_MP_COLOR_7',
+GREEN         = 'BLIP_MODIFIER_MP_COLOR_8',
+DARK_TEAL     = 'BLIP_MODIFIER_MP_COLOR_9',
+RED           = 'BLIP_MODIFIER_MP_COLOR_10',
+LIGHT_GREEN   = 'BLIP_MODIFIER_MP_COLOR_11',
+TEAL2         = 'BLIP_MODIFIER_MP_COLOR_12',
+BLUE          = 'BLIP_MODIFIER_MP_COLOR_13',
+DARK_PUPLE    = 'BLIP_MODIFIER_MP_COLOR_14',
+DARK_PINK     = 'BLIP_MODIFIER_MP_COLOR_15',
+DARK_DARK_RED = 'BLIP_MODIFIER_MP_COLOR_16',
+GRAY          = 'BLIP_MODIFIER_MP_COLOR_17',
+PINKISH       = 'BLIP_MODIFIER_MP_COLOR_18',
+YELLOW_GREEN  = 'BLIP_MODIFIER_MP_COLOR_19',
+DARK_GREEN    = 'BLIP_MODIFIER_MP_COLOR_20',
+BRIGHT_BLUE   = 'BLIP_MODIFIER_MP_COLOR_21',
+BRIGHT_PURPLE = 'BLIP_MODIFIER_MP_COLOR_22',
+YELLOW_ORANGE = 'BLIP_MODIFIER_MP_COLOR_23',
+BLUE2         = 'BLIP_MODIFIER_MP_COLOR_24',
+TEAL3         = 'BLIP_MODIFIER_MP_COLOR_25',
+TAN           = 'BLIP_MODIFIER_MP_COLOR_26',
+OFF_WHITE     = 'BLIP_MODIFIER_MP_COLOR_27',
+LIGHT_YELLOW2 = 'BLIP_MODIFIER_MP_COLOR_28',
+LIGHT_PINK    = 'BLIP_MODIFIER_MP_COLOR_29',
+LIGHT_RED     = 'BLIP_MODIFIER_MP_COLOR_30',
+LIGHT_YELLOW3 = 'BLIP_MODIFIER_MP_COLOR_31',
+WHITE         = 'BLIP_MODIFIER_MP_COLOR_32']]


### PR DESCRIPTION
When the hunter has no hint for the player's level, It won't open an empty menu; It will notify the player that he doesn't have enough level to access the menu. The notification message can be changed and configured in the config file.

One of the issues I have seen is, When the resource restarts, Blips and NPCs don't delete; if we restart a few times, we can see a few NPCs in the same location. I have fixed it, and now when the resource restarts blips and NPCs will be removed, and respawn the new blips and NPCs.

Added a feature to set the blip hash for each hunter in the config file.
Added a feature to set the blip name for each hunter in the config file.
Added a feature to set the blip color for each hunter in the config file. (I have commented on the blips colors we can use for blips in the below of config file)