### PR TITLE
Security fix for bcc:legendaries:giveitemsbear

### DIFF
--- a/client/menusetup.lua
+++ b/client/menusetup.lua
@@ -46,6 +46,14 @@ AddEventHandler('bcc:legendaries:openmenu', function(location)
                         if not Inmission then
                             TriggerServerEvent('bcc:legendaries:menuopen5', Cost, items.huntname, items.CooldownTime)
                             Data = items
+                            Data.id = k
+                            -- Debug items
+                            -- for kv, vk in pairs(Config.locations[Data.id].GivenItems) do 
+                            --     print(kv, vk)
+                            --     for key, value in pairs(vk) do 
+                            --         print(key, value)
+                            --     end
+                            -- end
                         else
                             VORPcore.NotifyBottomRight(_U('AlreadyInMission'), 4000)
                         end
@@ -67,6 +75,8 @@ AddEventHandler('bcc:legendaries:openmenu', function(location)
                     if not Inmission then
                         TriggerServerEvent('bcc:legendaries:menuopen5', Cost, items.huntname, items.CooldownTime)
                         Data = items
+                        Data.id = k
+                        -- print('Data id :', Data.id)
                     else
                         VORPcore.NotifyBottomRight(_U('AlreadyInMission'), 4000)
                     end
@@ -115,7 +125,9 @@ AddEventHandler('bcc-legendaries:DeadCheck', function()
     while true do
         Wait(1000)
         if IsPedDeadOrDying(PlayerPedId()) then
-            StopAll = true break
+            StopAll = true 
+            TriggerServerEvent('bcc-legendaries:stophunt')
+            break
         end
     end
 end)

--- a/client/skinned.lua
+++ b/client/skinned.lua
@@ -18,7 +18,7 @@ function skinnedped()
                     local player = PlayerPedId()
                     local playergate = player == ped
                     if playergate == true and bool_unk == 1 and model == model2 then --if the varaible Animal is the gator then
-                        TriggerServerEvent('bcc:legendaries:giveitemsbear', Data.GivenItems)
+                        TriggerServerEvent('bcc:legendaries:giveitemsbear', Data.k)
                         Wait(300000)
                         DeletePed(Createdped2)
                         break

--- a/client/skinned.lua
+++ b/client/skinned.lua
@@ -18,7 +18,7 @@ function skinnedped()
                     local player = PlayerPedId()
                     local playergate = player == ped
                     if playergate == true and bool_unk == 1 and model == model2 then --if the varaible Animal is the gator then
-                        TriggerServerEvent('bcc:legendaries:giveitemsbear', Data.k)
+                        TriggerServerEvent('bcc:legendaries:giveitemsbear', Data.id)
                         Wait(300000)
                         DeletePed(Createdped2)
                         break

--- a/config.lua
+++ b/config.lua
@@ -282,6 +282,7 @@ Config.Language = {
     Menuname = "Legendary Hunts",
     Hunterblip = "Hunter",
     Shoptext = 'Press "G" to see what the hunter is offering',
+    HuntActive = 'You have a hunt already active, finish it before starting a new one !',
     LegAnimalSpawned = 'The Animal is Nearby!',
     AnimalSkinned = 'You skinned the Animal, and got its pelt!',
     Leveldisp = 'Your Current Level',

--- a/config.lua
+++ b/config.lua
@@ -282,7 +282,6 @@ Config.Language = {
     Menuname = "Legendary Hunts",
     Hunterblip = "Hunter",
     Shoptext = 'Press "G" to see what the hunter is offering',
-    HuntActive = 'You have a hunt already active, finish it before starting a new one !',
     LegAnimalSpawned = 'The Animal is Nearby!',
     AnimalSkinned = 'You skinned the Animal, and got its pelt!',
     Leveldisp = 'Your Current Level',

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -28,7 +28,7 @@ client_scripts {
     '/client/skinned.lua'
 }
 
-version '1.2.2'
+version '1.2.3'
 
 dependency {
     'vorp_core',

--- a/server.lua
+++ b/server.lua
@@ -42,7 +42,8 @@ RegisterServerEvent('bcc:legendaries:menuopen5', function(Cost, shopid, cdownt)
 
   if activeHunts[_source] then
     VORPcore.NotifyBottomRight(_source, _U('HuntActive'), 6000)
-  return
+    return
+  end
 
 
   local Character = VORPcore.getUser(_source).getUsedCharacter

--- a/server.lua
+++ b/server.lua
@@ -18,7 +18,6 @@ end)
 RegisterServerEvent('bcc:legendaries:giveitemsbear', function(huntId)
   local _source = source
 
-  huntId = tonumber(huntId)
   if not activeHunts[_source] then
     return
   end

--- a/server.lua
+++ b/server.lua
@@ -41,7 +41,7 @@ RegisterServerEvent('bcc:legendaries:menuopen5', function(Cost, shopid, cdownt)
 
 
   if activeHunts[_source] then
-    VORPcore.NotifyBottomRight(_source, _U('HuntActive'), 6000)
+    VORPcore.NotifyBottomRight(_source, _U('AlreadyInMission'), 6000)
     return
   end
 

--- a/server.lua
+++ b/server.lua
@@ -13,14 +13,18 @@ TriggerEvent('bcc:getUtils', function(bccutils)
   BccUtils = bccutils
 end)
 
+
 ------------------------ Handles Giving Player Items when hunt over -----------------------
-RegisterServerEvent('bcc:legendaries:giveitemsbear', function(Rewards)
+RegisterServerEvent('bcc:legendaries:giveitemsbear', function(huntId)
   local _source = source
 
+  huntId = tonumber(huntId)
   if not activeHunts[_source] then
     return
   end
-
+  local huntConfig = Config.locations[tonumber(huntId)]
+ 
+  local Rewards = Config.locations[huntId].GivenItems
 
   for k, v in pairs(Rewards) do
     VorpInv.addItem(_source, v.name, v.count)
@@ -41,7 +45,7 @@ RegisterServerEvent('bcc:legendaries:menuopen5', function(Cost, shopid, cdownt)
 
 
   if activeHunts[_source] then
-    VORPcore.NotifyBottomRight(_source, _U('AlreadyInMission'), 6000)
+    VORPcore.NotifyBottomRight(_source, _U('HuntActive'), 6000)
     return
   end
 
@@ -82,6 +86,14 @@ RegisterServerEvent('bcc:legendaries:DBCheck', function(name)
       TriggerClientEvent('bcc-legendaries:ClientLevelCatch', _source, result2[1].trust, name) --passes trust to client
     end
   end
+end)
+
+
+---------- If you are dead, then it will stop the hunt
+RegisterServerEvent('bcc-legendaries:stophunt', function()
+  local _source = source
+
+  activeHunts[_source] = nil
 end)
 
 --This will handle version checking


### PR DESCRIPTION
I discovered that the Server Event could be exploited to obtain any item by providing the correct format. To address this, I implemented a fix where a table now tracks users with an active hunt. When an item event is receive, it checks if the user is in the table and then verifies the huntId before giving the items. This ensures that only hunt users can access the hunt items.